### PR TITLE
fix the compiling issue for Android project on Unix-like OS

### DIFF
--- a/HostMonitor/BuildAndroid/app/build.gradle
+++ b/HostMonitor/BuildAndroid/app/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.android.application'
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 android {
     compileSdkVersion 29
 
@@ -38,7 +40,10 @@ android {
     task createLink(type:Exec) {
         println 'create native source(UIcode) link'
         workingDir '.'
-        commandLine 'cmd', '/c', 'source-link.bat'
+        if (Os.isFamily(Os.FAMILY_WINDOWS))
+            commandLine 'cmd', '/c', 'source-link.bat'
+        else
+            commandLine 'sh', 'unix-link.sh'
     }
     preBuild.dependsOn(createLink)
 }

--- a/HostMonitor/BuildAndroid/app/unix-link.sh
+++ b/HostMonitor/BuildAndroid/app/unix-link.sh
@@ -1,0 +1,2 @@
+ln -s "$(pwd)/../../UIcode" "$(pwd)/src/main/cpp/UIcode"
+exit 0


### PR DESCRIPTION
Under project folder `HostMonitor/BuildAndroid/`, the logic related to create a link to `UIcode` is only for Windows.
So it won't compile for other OS.