### PR TITLE
fix: gcc11 compile error - mmap returned value is changed to MAP FAILED

### DIFF
--- a/Hello3D/BuildLinux/main.cpp
+++ b/Hello3D/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/Hello3Ddonut/BuildLinux/main.cpp
+++ b/Hello3Ddonut/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/Hello3Dwave/BuildLinux/main.cpp
+++ b/Hello3Dwave/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloAnimation/BuildLinux/main.cpp
+++ b/HelloAnimation/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloCircle/BuildLinux/main.cpp
+++ b/HelloCircle/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloFFmpeg/BuildLinux/main.cpp
+++ b/HelloFFmpeg/BuildLinux/main.cpp
@@ -142,7 +142,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloFont/BuildLinux/main.cpp
+++ b/HelloFont/BuildLinux/main.cpp
@@ -138,7 +138,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloFreetype/BuildLinux/main.cpp
+++ b/HelloFreetype/BuildLinux/main.cpp
@@ -138,7 +138,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloJPG/BuildLinux/main.cpp
+++ b/HelloJPG/BuildLinux/main.cpp
@@ -138,7 +138,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloKeypad/BuildLinux/main.cpp
+++ b/HelloKeypad/BuildLinux/main.cpp
@@ -143,7 +143,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloLayers/BuildLinux/main.cpp
+++ b/HelloLayers/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloMario/BuildLinux/main.cpp
+++ b/HelloMario/BuildLinux/main.cpp
@@ -134,7 +134,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloMolecule/BuildLinux/main.cpp
+++ b/HelloMolecule/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloNets/BuildLinux/main.cpp
+++ b/HelloNets/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloParticle/BuildLinux/main.cpp
+++ b/HelloParticle/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloPendulum/BuildLinux/main.cpp
+++ b/HelloPendulum/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloScroll/BuildLinux/main.cpp
+++ b/HelloScroll/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloSlide/BuildLinux/main.cpp
+++ b/HelloSlide/BuildLinux/main.cpp
@@ -139,7 +139,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloStar/BuildLinux/main.cpp
+++ b/HelloStar/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloTimer/BuildLinux/main.cpp
+++ b/HelloTimer/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloTransparent/BuildLinux/main.cpp
+++ b/HelloTransparent/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloWave/BuildLinux/main.cpp
+++ b/HelloWave/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloWidgets/BuildLinux/main.cpp
+++ b/HelloWidgets/BuildLinux/main.cpp
@@ -135,7 +135,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HelloWindows/BuildLinux/main.cpp
+++ b/HelloWindows/BuildLinux/main.cpp
@@ -138,7 +138,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HostMonitor/BuildGo/main.cpp
+++ b/HostMonitor/BuildGo/main.cpp
@@ -143,7 +143,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);

--- a/HostMonitor/BuildLinux/main.cpp
+++ b/HostMonitor/BuildLinux/main.cpp
@@ -148,7 +148,7 @@ static void* get_dev_fb(char* path, int &width, int &height, int &color_bytes)
     printf("vinfo.bits_per_pixel=%d\n",vinfo.bits_per_pixel);
 
 	void* fbp = mmap(0, (vinfo.xres * vinfo.yres * color_bytes), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if(0 > fbp)
+	if(fbp == MAP_FAILED)
 	{
 		perror("mmap fb failed!\n");  
 		_exit(-1);


### PR DESCRIPTION
fix: gcc11 compile error - mmap returned value is changed to MAP FAILED